### PR TITLE
WriteItem fix: get_burst_addresses takes avl.Logic instead of int

### DIFF
--- a/avl_axi/_item.py
+++ b/avl_axi/_item.py
@@ -486,7 +486,7 @@ class WriteItem(SequenceItem):
         # Post process wstrbs to be legal
         # Difficult to constrain so patch
         if hasattr(self, "wstrb"):
-            addresses = get_burst_addresses(self.awaddr,
+            addresses = get_burst_addresses(self.get("awaddr", default=0),
                                             self.get("awlen", default=0),
                                             self.get("awsize", default=0),
                                             self.get("awburst", default=axi_burst_t.INCR))


### PR DESCRIPTION
fixed this one point, where get_burst_addresses takes self.awaddr, which results in the output of the function being avl.Logic and not int, thus keeping the size limit of avl.Logic. this ends up messing the lshift operation further down the line.