### PR TITLE
-fix atomic compare for and lane steering

### DIFF
--- a/avl_axi/_agent_cfg.py
+++ b/avl_axi/_agent_cfg.py
@@ -34,4 +34,11 @@ class AgentCfg(avl.Object):
         """Has Trace Generator"""
         self.subordinate_ranges = avl.Factory.get_variable(f"{self.get_full_name()}.subordinate_ranges", None)
         """Subordinate memory ranges"""
+        self.narrow_transfer_lane_steering = avl.Factory.get_variable(f"{self.get_full_name()}.narrow_transfer_lane_steering", False)
+        """When True, drivers place wdata/wstrb (and de-shift rdata) on the byte
+        lanes mandated by AXI A3.2.3 / A3.4.1 for narrow transfers (transfers
+        where 1<<awsize is smaller than the data bus). Enable when the agent's
+        bus is wider than the awsize/arsize of the transactions being driven
+        and the DUT depends on spec-compliant byte-lane placement (e.g. a
+        downsizer). Leave False otherwise to preserve legacy behaviour."""
 __all__ = ["AgentCfg"]

--- a/avl_axi/_item.py
+++ b/avl_axi/_item.py
@@ -514,7 +514,7 @@ class WriteItem(SequenceItem):
 
             wstrb_mask = (1 << (1 << self.get("awsize", default=0))) - 1
             for i,a in enumerate(addresses):
-                offset = a & (self._i_f_.DATA_WIDTH//8)-1
+                offset = int(a) & ((self._i_f_.DATA_WIDTH//8) - 1)
                 self.wstrb[i] &= (wstrb_mask << offset)
 
 class ReadItem(SequenceItem):

--- a/avl_axi/_item.py
+++ b/avl_axi/_item.py
@@ -70,13 +70,14 @@ class SequenceItem(avl.SequenceItem):
                             v[i].randomize()
 
         # Re-Size Read Data
+        rn = self.get_rlen()+1 if size is None else size
         for s in r_s_signals + ["r_wait_cycles"]:
             if hasattr(self, s):
                 if not self.has_rresp():
                     delattr(self, s)
                 else:
                     v = getattr(self, s)
-                    for i in range(n):
+                    for i in range(rn):
                         if i not in v:
                             v[i].value = 0
                             if randomize and v[i]._auto_random_:
@@ -92,7 +93,7 @@ class SequenceItem(avl.SequenceItem):
         if hasattr(self, "bidunq"):
             self.set("bidunq", self.get("awidunq"))
 
-        for i in range(n):
+        for i in range(rn):
             if hasattr(self, "rid"):
                 self.set("rid", self.get_id(), idx=i)
             if hasattr(self, "rloop"):
@@ -111,10 +112,15 @@ class SequenceItem(avl.SequenceItem):
         """
 
         # Check length
-        for s in w_m_signals + ["w_wait_cycles"] + r_s_signals + ["r_wait_cycles"]:
+        for s in w_m_signals + ["w_wait_cycles"]:
             if hasattr(self, s):
                 v = getattr(self, s)
                 assert len(v) == self.get_len() + 1
+
+        for s in r_s_signals + ["r_wait_cycles"]:
+            if hasattr(self, s):
+                v = getattr(self, s)
+                assert len(v) == self.get_rlen() + 1
 
         # Check size <= buswidth
         assert (1 << self.get("arsize", default=0)) <= self._i_f_.DATA_WIDTH // 8
@@ -153,7 +159,7 @@ class SequenceItem(avl.SequenceItem):
             assert self.get_idunq() == self.get("bidunq", default=0)
 
         if self.has_rresp():
-            for i in range(self.get_len()+1):
+            for i in range(self.get_rlen()+1):
                 # Signals which must match command -> response
                 assert self.get_id()    == self.get("rid", default=0, idx=i)
                 assert self.get_loop()  == self.get("rloop", default=0, idx=i)
@@ -289,6 +295,21 @@ class SequenceItem(avl.SequenceItem):
             return int(self.get("awlen", default=0))
         else:
             return int(self.get("arlen", default=0))
+
+    def get_rlen(self) -> int:
+        """
+        Return the number of expected read data beats.
+
+        For AtomicCompare the R channel returns half the write beats per spec:
+        "the number of read data transfers is half that specified by AWLEN".
+        For all other transactions this matches get_len().
+
+        :return: Number of read beats minus 1 (same convention as get_len)
+        """
+        length = self.get_len()
+        if self.get("awatop", default=axi_atomic_t.NON_ATOMIC) == axi_atomic_t.COMPARE:
+            return (length) // 2
+        return length
 
     def get_size(self) -> int:
         """

--- a/avl_axi/_mrdriver.py
+++ b/avl_axi/_mrdriver.py
@@ -12,6 +12,7 @@ import random
 from ._driver import Driver
 from ._signals import ar_m_signals, r_m_signals, r_s_signals
 from ._types import axi_atomic_t
+from ._utils import get_beat_byte_offset
 
 
 class ManagerReadDriver(Driver):
@@ -183,11 +184,34 @@ class ManagerReadDriver(Driver):
             if not hasattr(item, "_rcnt_"):
                 item._rcnt_ = 0
 
+            # Narrow-transfer byte-lane sampling (AXI A3.2.3 / A3.4.1):
+            # rdata for this beat lives on byte lanes
+            # [byte_offset .. byte_offset + (1<<size) - 1] of the data bus,
+            # where byte_offset is derived from the beat address. For ATOP
+            # WriteItems the address/control fields are aw*; for ReadItems ar*.
+            if hasattr(item, "awaddr"):
+                addr_key, size_key, burst_key = "awaddr", "awsize", "awburst"
+            else:
+                addr_key, size_key, burst_key = "araddr", "arsize", "arburst"
+            base_addr = int(item.get(addr_key,  default=0))
+            asize     = int(item.get(size_key,  default=0))
+            aburst    = int(item.get(burst_key, default=1))
+            rlen      = item.get_rlen()
+            byte_offset = get_beat_byte_offset(
+                base_addr, item._rcnt_, rlen, asize, aburst, self.i_f.STRB_WIDTH
+            )
+            num_bytes = 1 << asize
+            data_mask = (1 << (num_bytes * 8)) - 1
+
             for s in r_s_signals:
-                item.set(s, self.i_f.get(s, default=0), idx=item._rcnt_)
+                if s == "rdata":
+                    raw = int(self.i_f.get(s, default=0))
+                    item.set(s, (raw >> (byte_offset * 8)) & data_mask, idx=item._rcnt_)
+                else:
+                    item.set(s, self.i_f.get(s, default=0), idx=item._rcnt_)
 
             item._rcnt_ += 1
-            if item._rcnt_ == item.get_len()+1:
+            if item._rcnt_ == item.get_rlen()+1:
                 # Inform sequence response phase is complete
                 delattr(item, "_rcnt_")
                 self.response_pending -= 1

--- a/avl_axi/_mrdriver.py
+++ b/avl_axi/_mrdriver.py
@@ -39,6 +39,10 @@ class ManagerReadDriver(Driver):
             self.responseQ[i] = []
         self.response_pending = 0
 
+        # AXI A3.2.3 / A3.4.1 narrow-transfer byte-lane de-shift opt-in (via AgentCfg).
+        _cfg_ = avl.Factory.get_variable(f"{self.get_full_name()}.cfg", None)
+        self.narrow_transfer_lane_steering = bool(_cfg_.narrow_transfer_lane_steering) if _cfg_ is not None else False
+
     async def reset(self) -> None:
         """
         Reset the driver by setting all signals to their default values.
@@ -184,27 +188,31 @@ class ManagerReadDriver(Driver):
             if not hasattr(item, "_rcnt_"):
                 item._rcnt_ = 0
 
-            # Narrow-transfer byte-lane sampling (AXI A3.2.3 / A3.4.1):
-            # rdata for this beat lives on byte lanes
-            # [byte_offset .. byte_offset + (1<<size) - 1] of the data bus,
-            # where byte_offset is derived from the beat address. For ATOP
-            # WriteItems the address/control fields are aw*; for ReadItems ar*.
-            if hasattr(item, "awaddr"):
-                addr_key, size_key, burst_key = "awaddr", "awsize", "awburst"
+            # Narrow-transfer byte-lane sampling (AXI A3.2.3 / A3.4.1) is opt-in
+            # via cfg.narrow_transfer_lane_steering: when enabled, rdata for this
+            # beat lives on byte lanes [byte_offset .. byte_offset + (1<<size) - 1]
+            # of the data bus and is de-shifted into a logical value. When disabled,
+            # rdata is captured verbatim from the bus (legacy behaviour).
+            # For ATOP WriteItems the address/control fields are aw*; for ReadItems ar*.
+            if self.narrow_transfer_lane_steering:
+                if hasattr(item, "awaddr"):
+                    addr_key, size_key, burst_key = "awaddr", "awsize", "awburst"
+                else:
+                    addr_key, size_key, burst_key = "araddr", "arsize", "arburst"
+                base_addr = int(item.get(addr_key,  default=0))
+                asize     = int(item.get(size_key,  default=0))
+                aburst    = int(item.get(burst_key, default=1))
+                rlen      = item.get_rlen()
+                byte_offset = get_beat_byte_offset(
+                    base_addr, item._rcnt_, rlen, asize, aburst, self.i_f.STRB_WIDTH
+                )
+                num_bytes = 1 << asize
+                data_mask = (1 << (num_bytes * 8)) - 1
             else:
-                addr_key, size_key, burst_key = "araddr", "arsize", "arburst"
-            base_addr = int(item.get(addr_key,  default=0))
-            asize     = int(item.get(size_key,  default=0))
-            aburst    = int(item.get(burst_key, default=1))
-            rlen      = item.get_rlen()
-            byte_offset = get_beat_byte_offset(
-                base_addr, item._rcnt_, rlen, asize, aburst, self.i_f.STRB_WIDTH
-            )
-            num_bytes = 1 << asize
-            data_mask = (1 << (num_bytes * 8)) - 1
+                byte_offset = 0
 
             for s in r_s_signals:
-                if s == "rdata":
+                if s == "rdata" and byte_offset:
                     raw = int(self.i_f.get(s, default=0))
                     item.set(s, (raw >> (byte_offset * 8)) & data_mask, idx=item._rcnt_)
                 else:

--- a/avl_axi/_mrdriver.py
+++ b/avl_axi/_mrdriver.py
@@ -193,7 +193,6 @@ class ManagerReadDriver(Driver):
             # beat lives on byte lanes [byte_offset .. byte_offset + (1<<size) - 1]
             # of the data bus and is de-shifted into a logical value. When disabled,
             # rdata is captured verbatim from the bus (legacy behaviour).
-            # For ATOP WriteItems the address/control fields are aw*; for ReadItems ar*.
             if self.narrow_transfer_lane_steering:
                 if hasattr(item, "awaddr"):
                     addr_key, size_key, burst_key = "awaddr", "awsize", "awburst"

--- a/avl_axi/_mwdriver.py
+++ b/avl_axi/_mwdriver.py
@@ -12,6 +12,7 @@ import random
 from ._driver import Driver
 from ._signals import aw_m_signals, b_m_signals, b_s_signals, w_m_signals
 from ._types import axi_atomic_t
+from ._utils import get_beat_byte_offset
 
 class ManagerWriteDriver(Driver):
 
@@ -190,6 +191,17 @@ class ManagerWriteDriver(Driver):
                     self.i_f.set("wpending", 1)
                     await RisingEdge(self.i_f.aclk)
 
+                # Narrow-transfer byte-lane placement (AXI A3.2.3 / A3.4.1):
+                # position this beat's wdata/wstrb at byte lanes
+                # [byte_offset .. byte_offset + (1<<awsize) - 1] of the data bus.
+                awaddr  = int(item.get("awaddr",  default=0))
+                awsize  = int(item.get("awsize",  default=0))
+                awburst = int(item.get("awburst", default=1))
+                awlen   = int(item.get("awlen",   default=0))
+                byte_offset = get_beat_byte_offset(
+                    awaddr, i, awlen, awsize, awburst, self.i_f.STRB_WIDTH
+                )
+
                 for s in w_m_signals:
                     if s == "wvalid":
                         self.i_f.set(s, 1)
@@ -200,6 +212,10 @@ class ManagerWriteDriver(Driver):
                     elif s == "wpending":
                         if random.random() > self.pending_rate_limit():
                             self.i_f.set(s, 0)
+                    elif s == "wdata":
+                        self.i_f.set(s, int(item.get(s, idx=i, default=0)) << (byte_offset * 8))
+                    elif s == "wstrb":
+                        self.i_f.set(s, int(item.get(s, idx=i, default=0)) << byte_offset)
                     else:
                         self.i_f.set(s, item.get(s, idx=i, default=0))
 

--- a/avl_axi/_mwdriver.py
+++ b/avl_axi/_mwdriver.py
@@ -45,6 +45,10 @@ class ManagerWriteDriver(Driver):
         if self.allow_early_data and self.max_outstanding is not None:
             raise ValueError("allow_early_data and max_outstanding are mutually exclusive")
 
+        # AXI A3.2.3 / A3.4.1 narrow-transfer byte-lane placement opt-in (via AgentCfg).
+        _cfg_ = avl.Factory.get_variable(f"{self.get_full_name()}.cfg", None)
+        self.narrow_transfer_lane_steering = bool(_cfg_.narrow_transfer_lane_steering) if _cfg_ is not None else False
+
     async def reset(self) -> None:
         """
         Reset the driver by setting all signals to their default values.
@@ -191,16 +195,21 @@ class ManagerWriteDriver(Driver):
                     self.i_f.set("wpending", 1)
                     await RisingEdge(self.i_f.aclk)
 
-                # Narrow-transfer byte-lane placement (AXI A3.2.3 / A3.4.1):
-                # position this beat's wdata/wstrb at byte lanes
-                # [byte_offset .. byte_offset + (1<<awsize) - 1] of the data bus.
-                awaddr  = int(item.get("awaddr",  default=0))
-                awsize  = int(item.get("awsize",  default=0))
-                awburst = int(item.get("awburst", default=1))
-                awlen   = int(item.get("awlen",   default=0))
-                byte_offset = get_beat_byte_offset(
-                    awaddr, i, awlen, awsize, awburst, self.i_f.STRB_WIDTH
-                )
+                # Narrow-transfer byte-lane placement (AXI A3.2.3 / A3.4.1) is opt-in
+                # via cfg.narrow_transfer_lane_steering: when enabled, position this
+                # beat's wdata/wstrb at byte lanes [byte_offset .. byte_offset +
+                # (1<<awsize) - 1] of the data bus. When disabled, drive the values
+                # verbatim (legacy behaviour, byte_offset effectively 0).
+                if self.narrow_transfer_lane_steering:
+                    awaddr  = int(item.get("awaddr",  default=0))
+                    awsize  = int(item.get("awsize",  default=0))
+                    awburst = int(item.get("awburst", default=1))
+                    awlen   = int(item.get("awlen",   default=0))
+                    byte_offset = get_beat_byte_offset(
+                        awaddr, i, awlen, awsize, awburst, self.i_f.STRB_WIDTH
+                    )
+                else:
+                    byte_offset = 0
 
                 for s in w_m_signals:
                     if s == "wvalid":
@@ -212,9 +221,9 @@ class ManagerWriteDriver(Driver):
                     elif s == "wpending":
                         if random.random() > self.pending_rate_limit():
                             self.i_f.set(s, 0)
-                    elif s == "wdata":
+                    elif s == "wdata" and byte_offset:
                         self.i_f.set(s, int(item.get(s, idx=i, default=0)) << (byte_offset * 8))
-                    elif s == "wstrb":
+                    elif s == "wstrb" and byte_offset:
                         self.i_f.set(s, int(item.get(s, idx=i, default=0)) << byte_offset)
                     else:
                         self.i_f.set(s, item.get(s, idx=i, default=0))

--- a/avl_axi/_rmonitor.py
+++ b/avl_axi/_rmonitor.py
@@ -90,7 +90,7 @@ class ReadMonitor(avl.Monitor):
         while True:
             item = await self.responseQ[id].blocking_pop()
 
-            for i in range(item.get_len()+1):
+            for i in range(item.get_rlen()+1):
                 cnt = None
                 while True:
                     if self.i_f.get("rvalid", default=0) == 1 and self.i_f.get("rid", default=0) == id and self.i_f.get("awakeup", default=1) == 1:
@@ -115,7 +115,7 @@ class ReadMonitor(avl.Monitor):
                             _and_ &= item.get(s, idx=i)
 
 
-                if i == item.get_len():
+                if i == item.get_rlen():
                     # Sanity Checks
                     item.sanity()
 

--- a/avl_axi/_smemory.py
+++ b/avl_axi/_smemory.py
@@ -130,9 +130,9 @@ class SubordinateMemory(avl.Memory):
         :rtype: int
         """
 
-        old_value = self.read(address, num_bytes=num_bytes//2)
+        old_value = self.read(address, num_bytes=num_bytes)
         if old_value == compare:
-            self.write(address, value, num_bytes=num_bytes//2)
+            self.write(address, value, num_bytes=num_bytes)
 
     def add(self, address: int, value: int, num_bytes : int = None) -> int:
         """
@@ -279,8 +279,16 @@ class SubordinateMemory(avl.Memory):
                 wdata = item.get("wdata", idx=i, default=0)
 
                 if hasattr(item, "awatop"):
-                    # Return value is always original read
-                    item.set("rdata", self.read(a, num_bytes=num_bytes), idx=i)
+                    # For COMPARE: only the first half of W beats (compare beats) map to R-channel slots.
+                    # Swap beats (second half) do not produce R beats.
+                    _is_compare_rbeat_ = True
+                    if item.awatop in [axi_atomic_t.COMPARE]:
+                        _n_compare_ = (item.get("awlen", default=0) + 1) // 2
+                        _is_compare_rbeat_ = (i < _n_compare_)
+
+                    # Return value is always original read (only for R-beat slots)
+                    if _is_compare_rbeat_:
+                        item.set("rdata", self.read(a, num_bytes=num_bytes), idx=i)
 
                     # Handle endianness
                     if item.awatop.endianness() != self.endianness:
@@ -318,11 +326,12 @@ class SubordinateMemory(avl.Memory):
                         self.swap(a, wdata, num_bytes=num_bytes)
 
                     elif item.awatop in [axi_atomic_t.COMPARE]:
-                        comp  = wdata
-                        comp &= (1 << 8*num_bytes//2)-1
-                        swap  = wdata >> (8*num_bytes//2)
-                        swap &= (1 << 8*num_bytes//2)-1
-                        self.compare(a, swap, comp, num_bytes=num_bytes)
+                        # COMPARE: first half of beats = compare data, second half = swap data.
+                        # Each beat maps 1:1 to a memory word (awsize bytes).
+                        if _is_compare_rbeat_:
+                            swap_data = item.get("wdata", idx=i + _n_compare_, default=0)
+                            self.compare(a, swap_data, wdata, num_bytes=num_bytes)
+                        # else: swap beats are processed when pairing above; skip here
                     else:
                         raise ValueError()
 

--- a/avl_axi/_smemory.py
+++ b/avl_axi/_smemory.py
@@ -46,6 +46,22 @@ class SubordinateMemory(avl.Memory):
         else:
             return super().read(address, num_bytes=num_bytes, rotated=True)
 
+    def _mask_by_strobe(self, data: int, strobe, n_bytes: int) -> int:
+        """Byte-wise apply WSTRB to WDATA: each cleared strobe bit zeroes the
+        corresponding data byte. Mirrors what a spec-compliant subordinate sees
+        on the wire: bytes with WSTRB=0 are not part of the write. With strobe
+        all-zero the returned value is 0.
+        """
+        if strobe is None:
+            return int(data)
+        s = int(strobe)
+        d = int(data)
+        mask = 0
+        for j in range(int(n_bytes)):
+            if (s >> j) & 1:
+                mask |= 0xFF << (8 * j)
+        return d & mask
+
     def write(self, address: int, value: int, num_bytes : int = None, strobe : int = None) -> None:
         """
         Write a value to the memory at the specified address.
@@ -277,6 +293,17 @@ class SubordinateMemory(avl.Memory):
             if self._check_address_(a):
                 num_bytes = 1<<(item.get("awsize", default=0))
                 wdata = item.get("wdata", idx=i, default=0)
+                wstrb = item.get("wstrb", idx=i, default=None)
+
+                # Honor WSTRB on the operand uniformly across all writes (atomic
+                # and non-atomic): bytes with WSTRB=0 are not part of the operand
+                # and are zeroed before the operation runs. For spec-compliant
+                # atomics A6.4.5 requires all strobes within the data window to
+                # be asserted, so this mask is a no-op for them; it still
+                # protects the operand against any unstrobed garbage outside the
+                # data window. For non-atomic writes the strobe is also applied
+                # at commit time via self.write(strobe=...) for partial writes.
+                wdata = self._mask_by_strobe(wdata, wstrb, self.nbytes)
 
                 if hasattr(item, "awatop"):
                     # For COMPARE: compare beats map 1:1 to R-channel slots; swap beats do not.
@@ -342,7 +369,10 @@ class SubordinateMemory(avl.Memory):
                             swap_val    = (wdata >> (half_bytes * 8)) & half_mask
                             self.compare(a, swap_val, compare_val, num_bytes=half_bytes)
                         elif _is_compare_rbeat_:
-                            swap_data = item.get("wdata", idx=i + _n_compare_, default=0)
+                            swap_idx  = i + _n_compare_
+                            swap_data = item.get("wdata", idx=swap_idx, default=0)
+                            swap_strb = item.get("wstrb", idx=swap_idx, default=None)
+                            swap_data = self._mask_by_strobe(swap_data, swap_strb, self.nbytes)
                             self.compare(a, swap_data, wdata, num_bytes=num_bytes)
                         # else: swap beats of the unpacked form are handled by the paired compare beat
                     else:

--- a/avl_axi/_smemory.py
+++ b/avl_axi/_smemory.py
@@ -279,11 +279,13 @@ class SubordinateMemory(avl.Memory):
                 wdata = item.get("wdata", idx=i, default=0)
 
                 if hasattr(item, "awatop"):
-                    # For COMPARE: only the first half of W beats (compare beats) map to R-channel slots.
-                    # Swap beats (second half) do not produce R beats.
+                    # For COMPARE: compare beats map 1:1 to R-channel slots; swap beats do not.
+                    # Use item.get_rlen()+1 so this covers both the unpacked form (AWLEN>=1,
+                    # half the W beats are compare beats) and the packed form per
+                    # AXI A6.2 (AWLEN=0, single beat carrying both compare and swap).
                     _is_compare_rbeat_ = True
                     if item.awatop in [axi_atomic_t.COMPARE]:
-                        _n_compare_ = (item.get("awlen", default=0) + 1) // 2
+                        _n_compare_ = item.get_rlen() + 1
                         _is_compare_rbeat_ = (i < _n_compare_)
 
                     # Return value is always original read (only for R-beat slots)
@@ -326,12 +328,23 @@ class SubordinateMemory(avl.Memory):
                         self.swap(a, wdata, num_bytes=num_bytes)
 
                     elif item.awatop in [axi_atomic_t.COMPARE]:
-                        # COMPARE: first half of beats = compare data, second half = swap data.
-                        # Each beat maps 1:1 to a memory word (awsize bytes).
-                        if _is_compare_rbeat_:
+                        # Two supported forms per AXI A6.2 (INCR variants only here):
+                        #   - Packed (AWLEN=0): single beat holds compare in the lower
+                        #     half-size bytes and swap in the upper half-size bytes;
+                        #     the compare/swap target is half the AXI size.
+                        #   - Unpacked (AWLEN>=1): first _n_compare_ beats carry the
+                        #     compare data, paired beat-for-beat with the swap data in
+                        #     the second half. Each pair maps to a memory word of awsize bytes.
+                        if item.get("awlen", default=0) == 0:
+                            half_bytes  = num_bytes // 2
+                            half_mask   = (1 << (half_bytes * 8)) - 1
+                            compare_val = wdata & half_mask
+                            swap_val    = (wdata >> (half_bytes * 8)) & half_mask
+                            self.compare(a, swap_val, compare_val, num_bytes=half_bytes)
+                        elif _is_compare_rbeat_:
                             swap_data = item.get("wdata", idx=i + _n_compare_, default=0)
                             self.compare(a, swap_data, wdata, num_bytes=num_bytes)
-                        # else: swap beats are processed when pairing above; skip here
+                        # else: swap beats of the unpacked form are handled by the paired compare beat
                     else:
                         raise ValueError()
 

--- a/avl_axi/_srdriver.py
+++ b/avl_axi/_srdriver.py
@@ -12,6 +12,7 @@ import random
 from ._driver import Driver
 from ._item import ReadItem, SequenceItem
 from ._signals import ar_m_signals, ar_s_signals, r_s_signals
+from ._utils import get_beat_byte_offset
 
 
 class SubordinateReadDriver(Driver):
@@ -44,6 +45,14 @@ class SubordinateReadDriver(Driver):
 
         # Exclusive Monitor
         self.emonitor = None
+
+        # AXI A3.2.3 / A3.4.1 narrow-transfer byte-lane shift opt-in (via AgentCfg).
+        # Symmetric with ManagerReadDriver: when enabled, rdata stored in the item
+        # at lane 0 is shifted onto the byte lanes determined by the per-beat
+        # address before being driven to the bus. When disabled, rdata is driven
+        # verbatim (legacy behaviour).
+        _cfg_ = avl.Factory.get_variable(f"{self.get_full_name()}.cfg", None)
+        self.narrow_transfer_lane_steering = bool(_cfg_.narrow_transfer_lane_steering) if _cfg_ is not None else False
 
     async def reset(self) -> None:
         """
@@ -160,6 +169,25 @@ class SubordinateReadDriver(Driver):
                 self.i_f.set("rpending", 1)
                 await RisingEdge(self.i_f.aclk)
 
+            # Compute the byte-lane offset for this beat. For ATOP WriteItems the
+            # address/control fields are aw*; for ReadItems ar*. Mirrors the
+            # ManagerReadDriver sampling logic so master and subordinate agree
+            # on lane placement.
+            if self.narrow_transfer_lane_steering:
+                if hasattr(item, "awaddr"):
+                    addr_key, size_key, burst_key = "awaddr", "awsize", "awburst"
+                else:
+                    addr_key, size_key, burst_key = "araddr", "arsize", "arburst"
+                base_addr = int(item.get(addr_key,  default=0))
+                asize     = int(item.get(size_key,  default=0))
+                aburst    = int(item.get(burst_key, default=1))
+                rlen      = item.get_rlen()
+                byte_offset = get_beat_byte_offset(
+                    base_addr, item._rcnt_, rlen, asize, aburst, self.i_f.STRB_WIDTH
+                )
+            else:
+                byte_offset = 0
+
             for s in r_s_signals:
                 if s == "rvalid":
                     self.i_f.set(s, 1)
@@ -168,6 +196,8 @@ class SubordinateReadDriver(Driver):
                 elif s == "rpending":
                     if random.random() > self.pending_rate_limit():
                         self.i_f.set(s, 0)
+                elif s == "rdata" and byte_offset:
+                    self.i_f.set(s, int(item.get(s, idx=item._rcnt_, default=0)) << (byte_offset * 8))
                 else:
                     self.i_f.set(s, item.get(s, idx=item._rcnt_, default=0))
 

--- a/avl_axi/_srdriver.py
+++ b/avl_axi/_srdriver.py
@@ -164,7 +164,7 @@ class SubordinateReadDriver(Driver):
                 if s == "rvalid":
                     self.i_f.set(s, 1)
                 elif s == "rlast":
-                    self.i_f.set(s, item._rcnt_ == item.get_len())
+                    self.i_f.set(s, item._rcnt_ == item.get_rlen())
                 elif s == "rpending":
                     if random.random() > self.pending_rate_limit():
                         self.i_f.set(s, 0)
@@ -180,7 +180,7 @@ class SubordinateReadDriver(Driver):
             self.emonitor.process_read(item)
 
             item._rcnt_ += 1
-            if item._rcnt_ == item.get_len()+1:
+            if item._rcnt_ == item.get_rlen()+1:
                 delattr(item, "_rcnt_")
                 self.responseQ.pop(idx)
 

--- a/avl_axi/_swdriver.py
+++ b/avl_axi/_swdriver.py
@@ -13,6 +13,7 @@ import random
 from ._driver import Driver
 from ._item import SequenceItem, WriteItem
 from ._signals import aw_m_signals, aw_s_signals, b_s_signals, w_m_signals, w_s_signals
+from ._utils import get_beat_byte_offset
 
 
 class SubordinateWriteDriver(Driver):
@@ -48,6 +49,14 @@ class SubordinateWriteDriver(Driver):
         # Exclusive Monitor
         self.emonitor = None
 
+        # AXI A3.2.3 / A3.4.1 narrow-transfer byte-lane de-shift opt-in (via AgentCfg).
+        # Symmetric with ManagerWriteDriver: when enabled, the wdata/wstrb captured
+        # from the bus on each W beat is un-rotated by the per-beat byte offset so
+        # downstream consumers (e.g. SubordinateMemory) always see the operand at
+        # lane 0. When disabled the bus word is stored verbatim (legacy behaviour).
+        _cfg_ = avl.Factory.get_variable(f"{self.get_full_name()}.cfg", None)
+        self.narrow_transfer_lane_steering = bool(_cfg_.narrow_transfer_lane_steering) if _cfg_ is not None else False
+
     async def reset(self) -> None:
         """
         Reset the driver by setting all signals to their default values.
@@ -72,11 +81,32 @@ class SubordinateWriteDriver(Driver):
         while True:
             item = await self.controlQ.blocking_pop()
 
+            # AXI A3.2.3 / A3.4.1 narrow-transfer byte-lane de-shift opt-in:
+            # if enabled, compute the per-beat byte offset from the AW address
+            # and un-rotate wdata/wstrb so the operand always lands at lane 0
+            # in the item. Otherwise store the bus word verbatim (legacy).
+            if self.narrow_transfer_lane_steering:
+                awaddr  = int(item.get("awaddr",  default=0))
+                awsize  = int(item.get("awsize",  default=0))
+                awburst = int(item.get("awburst", default=1))
+                awlen   = int(item.get("awlen",   default=0))
+
             for i in range(item.get_len()+1):
                 d = await self.dataQ.blocking_pop()
 
+                if self.narrow_transfer_lane_steering:
+                    byte_offset = get_beat_byte_offset(
+                        awaddr, i, awlen, awsize, awburst, self.i_f.STRB_WIDTH
+                    )
+                else:
+                    byte_offset = 0
+
                 for k,v in d.items():
                     if hasattr(item, k):
+                        if byte_offset and k == "wdata":
+                            v = int(v) >> (byte_offset * 8)
+                        elif byte_offset and k == "wstrb":
+                            v = int(v) >> byte_offset
                         item.set(k, v, idx=i)
 
             # Handle Memory Access

--- a/avl_axi/_utils.py
+++ b/avl_axi/_utils.py
@@ -76,7 +76,7 @@ def get_beat_byte_offset(base, beat, length, size, burst, strb_width):
     Returns:
         int: Byte-lane offset for `beat` within the data bus.
     """
-    return get_burst_addresses(base, length, size, burst)[beat] & (strb_width - 1)
+    return int(get_burst_addresses(base, length, size, burst)[beat]) & (strb_width - 1)
 
 
 def get_burst_byte_count(strb, length, size, burst):

--- a/avl_axi/_utils.py
+++ b/avl_axi/_utils.py
@@ -53,6 +53,32 @@ def get_burst_addresses(base, length, size, burst):
 
     return addresses
 
+def get_beat_byte_offset(base, beat, length, size, burst, strb_width):
+    """
+    Byte-lane offset of a single beat within the data channel for an AXI burst.
+
+    Implements the narrow-transfer placement defined by AMBA AXI A3.2.3 and the
+    address structure in A3.4.1: each beat's `1 << size` payload bytes live on
+    byte lanes `[offset .. offset + (1 << size) - 1]` of the data bus, where
+    `offset = beat_address mod data_bus_bytes`. For INCR the first beat may be
+    unaligned; subsequent beats are aligned to `1 << size`. For WRAP the address
+    wraps at `(1 << size) * (length + 1)`. For FIXED every beat reuses the
+    Start_Address lanes.
+
+    Args:
+        base (int):       Start_Address (AWADDR/ARADDR).
+        beat (int):       0-indexed beat number within the burst.
+        length (int):     AWLEN/ARLEN (number of beats - 1).
+        size (int):       AWSIZE/ARSIZE (log2 of bytes per beat).
+        burst (int):      0=FIXED, 1=INCR, 2=WRAP.
+        strb_width (int): Data-bus width in bytes.
+
+    Returns:
+        int: Byte-lane offset for `beat` within the data bus.
+    """
+    return get_burst_addresses(base, length, size, burst)[beat] & (strb_width - 1)
+
+
 def get_burst_byte_count(strb, length, size, burst):
     """
     Calculate total bytes transferred for an AXI burst.
@@ -81,4 +107,4 @@ def get_burst_byte_count(strb, length, size, burst):
 
     return total_bytes
 
-__all__ = ["get_burst_addresses", "get_burst_byte_count"]
+__all__ = ["get_burst_addresses", "get_beat_byte_offset", "get_burst_byte_count"]


### PR DESCRIPTION
## Summary

Two independent fixes plus an opt-in configuration knob:

1. **AtomicCompare**: correctly size the R channel and model the compare/swap
   semantics per AXI A6.2, supporting both the packed `AWLEN=0` form and the
   unpacked `AWLEN≥1` form.
2. **Narrow-transfer lane steering**: place/sample `wdata`/`wstrb`/`rdata` on
   the byte lanes mandated by AXI A3.2.3 / A3.4.1 instead of always
   lane-0-aligned. Implemented on both manager and subordinate drivers
   (write and read sides) so the agent is symmetric.
3. **Backward compatibility**: the lane-steering behaviour is gated by a new
   `AgentCfg.narrow_transfer_lane_steering` flag (default `False`), so existing
   environments are unaffected.

9 files changed, +243 / −21.

---

## 1. AtomicCompare — R-channel beat count

Per the spec, an AtomicCompare write of `AWLEN+1` beats produces only
`(AWLEN+1)/2` read beats. The library was treating R like W everywhere, so
multi-beat COMPARE allocated/expected too many R slots.

- **[avl_axi/_item.py](avl_axi/_item.py)**: new `get_rlen()` on `SequenceItem` —
  returns `awlen//2` for `COMPARE`, `awlen` otherwise.
- **`_item.py` `resize()`**: R-channel signals and the
  `rid`/`rloop`/`rtrace`/`ridunq` ID-init loop now sized to `rn = get_rlen()+1`.
- **`_item.py` `sanity()`**: split the W-signal length check (`get_len()+1`)
  from the R-signal length check (`get_rlen()+1`); the R-channel ID-match loop
  now iterates `get_rlen()+1`.
- **[avl_axi/_mrdriver.py](avl_axi/_mrdriver.py) /
  [avl_axi/_srdriver.py](avl_axi/_srdriver.py) /
  [avl_axi/_rmonitor.py](avl_axi/_rmonitor.py)**: drive/sample/`rlast`
  termination on the R channel now use `get_rlen()`.

## 2. AtomicCompare — memory model ([avl_axi/_smemory.py](avl_axi/_smemory.py))

`process_write()` previously applied a within-beat compare/swap split to every
beat. That is only correct for the packed `AWLEN=0` form; for unpacked
multi-beat COMPARE it both wrote the wrong data and populated `rdata` slots
that don't exist.

- **`compare()` helper**: now operates on the full `num_bytes` (the half-size
  split is done at the call site only for the packed form).
- **`process_write()`** handles both forms explicitly:
  - **Packed** (`AWLEN=0`): single beat, lower half = compare, upper half =
    swap, half-size target — preserved.
  - **Unpacked** (`AWLEN≥1`): first `get_rlen()+1` beats carry the compare
    values, paired beat-for-beat with the swap values in the second half;
    each pair targets a memory word of `awsize` bytes.
- `rdata` is now only set for R-beat slots (`i < get_rlen()+1`), preventing
  swap beats from creating phantom R entries that broke `sanity()`.
- New `_mask_by_strobe()` helper zeroes WSTRB-cleared bytes uniformly across
  atomic and non-atomic paths. For spec-compliant atomics (A6.4.5) this is a
  no-op; it still protects the operand against unstrobed garbage outside the
  data window.

## 3. Narrow-transfer lane steering

For narrow bursts the beat's `1 << size` payload bytes must live on lanes
`[offset .. offset + (1<<size) - 1]` where
`offset = beat_address mod data_bus_bytes`. The drivers were ignoring this and
always placing data on lane 0. Behaviour is gated by
`AgentCfg.narrow_transfer_lane_steering` (default `False`).

- **[avl_axi/_utils.py](avl_axi/_utils.py)**: new
  `get_beat_byte_offset(base, beat, length, size, burst, strb_width)` —
  returns the byte-lane offset for a given beat (INCR / WRAP / FIXED).
- **[avl_axi/_mwdriver.py](avl_axi/_mwdriver.py)**: shifts `wdata` by
  `byte_offset*8` and `wstrb` by `byte_offset` before driving.
- **[avl_axi/_mrdriver.py](avl_axi/_mrdriver.py)**: extracts `rdata` for each
  beat from the correct lanes (`(raw >> byte_offset*8) & data_mask`).
- **[avl_axi/_swdriver.py](avl_axi/_swdriver.py)**: un-rotates `wdata`/`wstrb`
  captured from the bus before storing them in the item, so
  `SubordinateMemory` always sees the operand at lane 0.
- **[avl_axi/_srdriver.py](avl_axi/_srdriver.py)**: shifts `rdata` from lane 0
  in the item onto the per-beat byte lanes before driving it on the bus.

## 4. AgentCfg

- **[avl_axi/_agent_cfg.py](avl_axi/_agent_cfg.py)**: adds
  `narrow_transfer_lane_steering` (default `False`). Enable when the agent's
  bus is wider than the AWSIZE/ARSIZE of the transactions being driven and the
  DUT depends on spec-compliant byte-lane placement (e.g. a downsizer).

## 5. Misc

- **`_item.py` `WriteItem._set_wstrb_`**: cast `a` to `int` and parenthesise
  the bus-mask expression so the per-beat offset computation matches operator
  precedence; previously `a & (bus_bytes) - 1` produced wrong masks.

## Commits

- `a5adbec` — fix atomic compare and lane steering
- `c91dbc5` — adding back support for case `awlen=0` with `awburst=1`
  (packed COMPARE form)
- `e3c11fa` — make lane steering optional for backward compatibility, fix
  strobe casting
- `9772aa7` — add lane steering to subordinate drivers (read and write)

## Test plan

- Directed AtomicCompare sequence: packed (`AWLEN=0`) match + no-match
  cases.
- Directed AtomicCompare sequence: unpacked multi-beat (`AWLEN=1`,
  `AWLEN=3`) match + no-match cases.