### PR TITLE
Allow W data before AW address when allow_early_data=True

### DIFF
--- a/avl_axi/_mwdriver.py
+++ b/avl_axi/_mwdriver.py
@@ -176,7 +176,11 @@ class ManagerWriteDriver(Driver):
             item = self.dataQ.pop(0)
 
             # Wake
-            await item.wait_on_event("awake")
+            if not self.allow_early_data:
+                await item.wait_on_event("awake")
+            elif self.i_f.get("awakeup") is not None:
+                while self.i_f.get("awakeup") == 0:
+                    await RisingEdge(self.i_f.aclk)
 
             for i in range(item.get_len()+1):
                 self.i_f.set("wvalid", 0)

--- a/examples/axi/axi5-early-wdata/cocotb/example.py
+++ b/examples/axi/axi5-early-wdata/cocotb/example.py
@@ -46,7 +46,7 @@ async def test(dut):
 
     avl.Factory.set_variable("*.agent.mwdrv.control_rate_limit", lambda: 0.05)
     avl.Factory.set_variable("*.agent.mwdrv.data_rate_limit", lambda: 0.5)
-    avl.Factory.set_variable("*.agent.mwdrv.allow_early_data", False)
+    avl.Factory.set_variable("*.agent.mwdrv.allow_early_data", True)
 
 
     avl.Factory.set_override_by_type(avl_axi.SubordinateReadDriver, avl_axi.SubordinateReadRandomDriver)


### PR DESCRIPTION
## Summary

Fixes the `allow_early_data` flag in `ManagerWriteDriver` which was ineffective
because `drive_data()` unconditionally waited on the per-item `"awake"` event
set by `drive_control()`.

- Skip the `awake` gate in `drive_data()` when `allow_early_data=True`
- Preserve AXI5 power-gating safety: wait on `awakeup` signal if present
- No behavior change when `allow_early_data=False` (default)
- Fix existing `axi5-early-wdata` example to actually enable the feature

Per AXI spec IHI 0022, A3.3: W data before AW address is legal.