### PR TITLE
Replace APB through AXI in documentation

### DIFF
--- a/doc/source/configuration/configuration.rst
+++ b/doc/source/configuration/configuration.rst
@@ -54,9 +54,9 @@ The recommended way to connect to the AVL environment is via the factory.
 
 .. code-block:: python
 
-    avl.Factory.set_variable("*.hdl", dut.apb_if)
+    avl.Factory.set_variable("*.hdl", dut.axi_if)
 
-When the agent is created it will automatically use this factory setting to connect to the APB interface.
+When the agent is created it will automatically use this factory setting to connect to the AXI interface.
 
 Parameterization
 ----------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,4 +1,4 @@
-.. avl-apb documentation master file
+.. avl-axi documentation master file
 
 Apheleia Verification Library - AMBA eXtensible Interface
 ==========================================================================


### PR DESCRIPTION
There were some minor references to APB instead of AXI in the documentation.