### PR TITLE
Corrected rresp behavior in case of exclusive read

### DIFF
--- a/avl_axi/_emonitor.py
+++ b/avl_axi/_emonitor.py
@@ -7,6 +7,7 @@ import avl
 
 from ._item import SequenceItem
 from ._types import axi_resp_t
+from ._utils import get_burst_addresses
 
 
 class ExclusivityMonitor(avl.Component):
@@ -118,6 +119,12 @@ class ExclusivityMonitor(avl.Component):
 
         if item.arlock:
             self.ranges[id] = (lo, hi)
+            for i,_ in enumerate(get_burst_addresses(item.get("araddr"),  # change rresp value to EXOKAY, since when arlock=1, rresp is always EXOKAY
+                                                 item.get("arlen", default=0),
+                                                 item.get("arsize", default=0),
+                                                 item.get("arburst", default=1)
+                                                )):
+                item.set("rresp", axi_resp_t.EXOKAY, idx=i)
 
 
 __all__ = ["ExclusivityMonitor"]

--- a/avl_axi/_srdriver.py
+++ b/avl_axi/_srdriver.py
@@ -188,6 +188,9 @@ class SubordinateReadDriver(Driver):
             else:
                 byte_offset = 0
 
+            # Exclusive monitor
+            self.emonitor.process_read(item)
+            
             for s in r_s_signals:
                 if s == "rvalid":
                     self.i_f.set(s, 1)
@@ -205,9 +208,6 @@ class SubordinateReadDriver(Driver):
                 await RisingEdge(self.i_f.aclk)
                 if self.i_f.get("rready", default=1):
                     break
-
-            # Exclusive monitor
-            self.emonitor.process_read(item)
 
             item._rcnt_ += 1
             if item._rcnt_ == item.get_rlen()+1:

--- a/examples/axi/axi5-exclusive/cocotb/example.py
+++ b/examples/axi/axi5-exclusive/cocotb/example.py
@@ -19,8 +19,13 @@ class DirectedSequence(avl_axi.ManagerSequence):
         self.info(f"Starting Directed Manager sequence {self.get_full_name()}")
         self.wait_for = "response"
 
+        # Test : Non exclusive read
+        rsp = await self.read(araddr=0x1000, arid=1, arsize=3, arlock=0)
+        assert rsp.rresp[0] == axi_resp_t.OKAY
+
         # Test : Normal operation
-        await self.read(araddr=0x1000, arid=1, arsize=3, arlock=1)
+        rsp = await self.read(araddr=0x1000, arid=1, arsize=3, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
 
         # Matching Exclusive Write - return EXOKAY
         rsp = await self.write(awaddr=0x1000, awid=1, awsize=3, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)
@@ -31,7 +36,8 @@ class DirectedSequence(avl_axi.ManagerSequence):
         assert rsp.bresp == axi_resp_t.OKAY
 
         # Test : Clear by partial Match (smaller)
-        await self.read(araddr=0x1000, arid=2, arsize=3, arlock=1)
+        rsp = await self.read(araddr=0x1000, arid=2, arsize=3, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
 
         # Partial Matching Exclusive Write - return OKAY
         rsp = await self.write(awaddr=0x1000, awid=2, awsize=2, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)
@@ -42,7 +48,8 @@ class DirectedSequence(avl_axi.ManagerSequence):
         assert rsp.bresp == axi_resp_t.OKAY
 
         # Test : Clear by artial Match (bigger)
-        await self.read(araddr=0x1000, arid=3, arsize=0, arlock=1)
+        rsp = await self.read(araddr=0x1000, arid=3, arsize=0, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
 
         # Partial Matching Exclusive Write - return OKAY
         rsp = await self.write(awaddr=0x1000, awid=3, awsize=2, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)
@@ -53,7 +60,8 @@ class DirectedSequence(avl_axi.ManagerSequence):
         assert rsp.bresp == axi_resp_t.OKAY
 
         # Test : Clear by Miss
-        await self.read(araddr=0x1000, arid=3, arsize=0, arlock=1)
+        rsp = await self.read(araddr=0x1000, arid=3, arsize=0, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
 
         # Partial Matching Exclusive Write - return OKAY
         rsp = await self.write(awaddr=0x2000, awid=3, awsize=2, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)
@@ -64,7 +72,8 @@ class DirectedSequence(avl_axi.ManagerSequence):
         assert rsp.bresp == axi_resp_t.OKAY
 
         # Test : Clear by exact match with other manager
-        await self.read(araddr=0x1000, arid=4, arsize=3, arlock=1)
+        rsp = await self.read(araddr=0x1000, arid=4, arsize=3, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
 
         # Partial Matching Exclusive Write - return OKAY
         rsp = await self.write(awaddr=0x1000, awid=1, awsize=3, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)
@@ -75,7 +84,8 @@ class DirectedSequence(avl_axi.ManagerSequence):
         assert rsp.bresp == axi_resp_t.OKAY
 
         # Test : Clear by partial match with other manager
-        await self.read(araddr=0x1000, arid=5, arsize=3, arlock=1)
+        rsp = await self.read(araddr=0x1000, arid=5, arsize=3, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
 
         # Partial Matching Exclusive Write - return OKAY
         rsp = await self.write(awaddr=0x1000, awid=2, awsize=1, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)
@@ -86,7 +96,8 @@ class DirectedSequence(avl_axi.ManagerSequence):
         assert rsp.bresp == axi_resp_t.OKAY
 
         # Test : No clear by write to different range
-        await self.read(araddr=0x1000, arid=0, arsize=3, arlock=1)
+        rsp = await self.read(araddr=0x1000, arid=0, arsize=3, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
 
         # Miss (different master) - return OKAY
         rsp = await self.write(awaddr=0x1020, awid=1, awsize=3, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)
@@ -97,35 +108,42 @@ class DirectedSequence(avl_axi.ManagerSequence):
         assert rsp.bresp == axi_resp_t.EXOKAY
 
         # Test : Update
-        await self.read(araddr=0x1000, arid=0, arsize=3, arlock=1)
-        await self.read(araddr=0x2000, arid=0, arsize=3, arlock=1)
+        rsp = await self.read(araddr=0x1000, arid=0, arsize=3, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
+        rsp = await self.read(araddr=0x2000, arid=0, arsize=3, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
 
         # Miss - would have hit first - return OK
         rsp = await self.write(awaddr=0x1000, awid=1, awsize=3, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)
         assert rsp.bresp == axi_resp_t.OKAY
 
         # Matching Exclusive Write - return EXOKAY
-        await self.read(araddr=0x1000, arid=0, arsize=3, arlock=1)
-        await self.read(araddr=0x2000, arid=0, arsize=3, arlock=1)
+        rsp = await self.read(araddr=0x1000, arid=0, arsize=3, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
+        rsp = await self.read(araddr=0x2000, arid=0, arsize=3, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
         rsp = await self.write(awaddr=0x2000, awid=0, awsize=3, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)
         assert rsp.bresp == axi_resp_t.EXOKAY
 
         # Test : Read burst - Write single Match
-        await self.read(araddr=0x1000, arid=1, arsize=3, arlen=2, awburst=1, arlock=1)
+        rsp = await self.read(araddr=0x1000, arid=1, arsize=3, arlen=2, awburst=1, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
 
         # Matching Exclusive Write - return EXOKAY
         rsp = await self.write(awaddr=0x1000, awid=1, awsize=3, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)
         assert rsp.bresp == axi_resp_t.EXOKAY
 
         # Test : Read Single - Write burst Match
-        await self.read(araddr=0x1000, arid=1, arsize=3, arlock=1)
+        rsp = await self.read(araddr=0x1000, arid=1, arsize=3, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
 
         # Matching Exclusive Write - return EXOKAY
         rsp = await self.write(awaddr=0x1000, awid=1, awsize=3, awlen=1, awburst=2, wdata=[0xdeadbeef, 0xcafebabe], wstrb=[0xFF]*2, awlock=1)
         assert rsp.bresp == axi_resp_t.EXOKAY
 
         # Test : Read Burst - Write miss 0
-        await self.read(araddr=0x1000, arid=1, arsize=3, arlen=1, awburst=1, arlock=1)
+        rsp = await self.read(araddr=0x1000, arid=1, arsize=3, arlen=1, awburst=1, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
 
         # Matching Exclusive Write (wrong beat) - return OKAY
         rsp = await self.write(awaddr=0x1008, awid=1, awsize=3, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)

--- a/examples/sim.mk
+++ b/examples/sim.mk
@@ -36,7 +36,3 @@ clean::
 	rm -rf cocotb/__pycache__/
 	rm -rf *.txt *.xml *.json *.csv *.yaml *.vcd *.png sim.log html transcript modelsim.ini ucli.key
 
-debug:
-	@echo "PYTHONPATH: $(PYTHONPATH)"
-	@echo "PWD: $(PWD)"
-	@echo "MAKEFILE_DIR: $(MAKEFILE_DIR)"


### PR DESCRIPTION
In this MR I've added:
- emonitor now returns EXOKAY in case of exclusive read (which is the expected behavior)
- changed srdriver so the emonitor happens before item values are applied tp interfaces (otherwise the EXOKAY is only applied in the next loop, and that causes bugs)
- added rresp check for the reads in axi5-exclusive example. also added a regular read in the beginning to make sure it doesn't return EXOKAY.
- removed the debug function in the makefile (that I probably put there by accident before)