### PR TITLE
Fix: clear response_pending on mid-sim reset in Manager Write/Read drivers

### DIFF
--- a/avl_axi/_mrdriver.py
+++ b/avl_axi/_mrdriver.py
@@ -54,6 +54,7 @@ class ManagerReadDriver(Driver):
         # Write Signals
         for s in ar_m_signals + r_m_signals:
             self.i_f.set(s, 0)
+        self.response_pending = 0
 
     async def quiesce_control(self) -> None:
         """

--- a/avl_axi/_mwdriver.py
+++ b/avl_axi/_mwdriver.py
@@ -60,6 +60,7 @@ class ManagerWriteDriver(Driver):
         # Write Signals
         for s in aw_m_signals + w_m_signals + b_m_signals:
             self.i_f.set(s, 0)
+        self.response_pending = 0
 
     async def quiesce_control(self) -> None:
         """


### PR DESCRIPTION
# Fix: clear `response_pending` on mid-sim reset in Manager Write/Read drivers

## Summary

`ManagerWriteDriver.response_pending` and `ManagerReadDriver.response_pending` are not
cleared when the driver handles a mid-simulation reset.
The base `Driver.wait_on_reset()` resets `_outstanding_transactions_`, `_unique_ids_`,
and `_tag_ids_` and calls the subclass `reset()`, but neither subclass `reset()` clears
its own `response_pending` counter.
This change adds `self.response_pending = 0` to the `reset()` method of both drivers.

## Impact

After a mid-sim reset, the restarted `drive_response()` clears its `responseQ` but inherits
a stale `response_pending > 0`.
As a result it falls straight through the `while self.response_pending == 0 ...` gate,
asserts `bready` / `rready`, and either:

- waits for a phantom response that never arrives, blocking the response channel; or
- raises `IndexError` when a real response arrives and `self.responseQ[bid].pop(0)` is
  called on the now-empty queue (the queue is cleared on restart but the count is not).

Any testbench that asserts reset mid-transaction and then sends new traffic hangs or crashes.

## Fix

`avl_axi/_mwdriver.py` — `ManagerWriteDriver.reset()`:

```python
async def reset(self) -> None:
    # Write Signals
    for s in aw_m_signals + w_m_signals + b_m_signals:
        self.i_f.set(s, 0)
    self.response_pending = 0
```

`avl_axi/_mrdriver.py` — `ManagerReadDriver.reset()`:

```python
async def reset(self) -> None:
    # Write Signals
    for s in ar_m_signals + r_m_signals:
        self.i_f.set(s, 0)
    self.response_pending = 0
```

`reset()` is invoked from the base `Driver.wait_on_reset()` (which awaits `FallingEdge(aresetn)`),
so the new line executes exactly when a mid-sim reset is detected, alongside the existing
clearing of `_outstanding_transactions_` / `_unique_ids_` / `_tag_ids_`.

## Validation

The existing example testbenches only apply an initial reset at startup; none exercises a
mid-simulation reset, so there is no existing fail-before/pass-after harness to extend
without authoring a new full cocotb + RTL example (which requires the simulation grid).
The fix is a minimal, targeted addition mirroring the base-class reset semantics.
