### PR TITLE
[AVL-AXI] Override SequenceItem.set_id() to match get_id()

### DIFF
--- a/avl_axi/_item.py
+++ b/avl_axi/_item.py
@@ -263,6 +263,18 @@ class SequenceItem(avl.SequenceItem):
         else:
             return int(self.get("arid", default=0))
 
+    def set_id(self, id: int) -> None:
+        """
+        Set ID
+
+        :param id: ID to set (awid for writes, arid for reads)
+        :type id: int
+        """
+        if hasattr(self, "awaddr"):
+            self.set("awid", id)
+        else:
+            self.set("arid", id)
+
     def get_idunq(self) -> int:
         """
         Return ID Unique


### PR DESCRIPTION
Add set_id() method to AXI SequenceItem to fix get_id(), set_id() imbalance.

Motivation:
`avl_axi._item.SequenceItem` overrides `get_id()` from the base `avl._core.transaction.Transaction` class to return the AXI protocol ID field (`awid` for writes, `arid` for reads). However, it does **not** override `set_id()`. The inherited `Transaction.set_id()` writes to `self._id_`, which `avl_axi`'s `get_id()` never reads — creating a silent, complete disconnect between the two methods.

Override `SequenceItem.set_id()` so that it updates the appropriate AXI ID field (`awid` or `arid`), matching the behavior of `get_id()` and restoring the expected getter/setter semantics.