### PR TITLE
_emonitor: EXOKAY fix on read

### DIFF
--- a/avl_axi/_emonitor.py
+++ b/avl_axi/_emonitor.py
@@ -124,7 +124,8 @@ class ExclusivityMonitor(avl.Component):
                                                  item.get("arsize", default=0),
                                                  item.get("arburst", default=1)
                                                 )):
-                item.set("rresp", axi_resp_t.EXOKAY, idx=i)
+                if item.get("rresp", idx=i, default=axi_resp_t.OKAY) == axi_resp_t.OKAY:  # only overwrite if rresp is OKAY, otherwise keep the original value (e.g., SLVERR)
+                    item.set("rresp", axi_resp_t.EXOKAY, idx=i)
 
 
 __all__ = ["ExclusivityMonitor"]

--- a/avl_axi/_emonitor.py
+++ b/avl_axi/_emonitor.py
@@ -118,7 +118,8 @@ class ExclusivityMonitor(avl.Component):
         (lo, hi) = self._get_range_(item)
 
         if item.arlock:
-            self.ranges[id] = (lo, hi)
+            if all([resp_type in item.get("rresp").values() for resp_type in [axi_resp_t.OKAY]]):  # check that we don't have any SLVERR or DECERR responses in the read response
+                self.ranges[id] = (lo, hi)
             for i,_ in enumerate(get_burst_addresses(item.get("araddr"),  # change rresp value to EXOKAY, since when arlock=1, rresp is always EXOKAY
                                                  item.get("arlen", default=0),
                                                  item.get("arsize", default=0),

--- a/examples/axi/axi5-exclusive/cocotb/example.py
+++ b/examples/axi/axi5-exclusive/cocotb/example.py
@@ -23,9 +23,17 @@ class DirectedSequence(avl_axi.ManagerSequence):
         rsp = await self.read(araddr=0x1000, arid=1, arsize=3, arlock=0)
         assert rsp.rresp[0] == axi_resp_t.OKAY
 
+        # Test : Non exclusive read - bad address
+        rsp = await self.read(araddr=0x3000, arid=1, arsize=3, arlock=0)
+        assert rsp.rresp[0] == axi_resp_t.DECERR
+
         # Test : Normal operation
         rsp = await self.read(araddr=0x1000, arid=1, arsize=3, arlock=1)
         assert rsp.rresp[0] == axi_resp_t.EXOKAY
+
+        # Test : Normal operation - bad address
+        rsp = await self.read(araddr=0x3000, arid=1, arsize=3, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.DECERR
 
         # Matching Exclusive Write - return EXOKAY
         rsp = await self.write(awaddr=0x1000, awid=1, awsize=3, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)

--- a/examples/axi/axi5-exclusive/cocotb/example.py
+++ b/examples/axi/axi5-exclusive/cocotb/example.py
@@ -27,13 +27,13 @@ class DirectedSequence(avl_axi.ManagerSequence):
         rsp = await self.read(araddr=0x3000, arid=1, arsize=3, arlock=0)
         assert rsp.rresp[0] == axi_resp_t.DECERR
 
-        # Test : Normal operation
-        rsp = await self.read(araddr=0x1000, arid=1, arsize=3, arlock=1)
-        assert rsp.rresp[0] == axi_resp_t.EXOKAY
-
         # Test : Normal operation - bad address
         rsp = await self.read(araddr=0x3000, arid=1, arsize=3, arlock=1)
         assert rsp.rresp[0] == axi_resp_t.DECERR
+
+        # Test : Normal operation
+        rsp = await self.read(araddr=0x1000, arid=1, arsize=3, arlock=1)
+        assert rsp.rresp[0] == axi_resp_t.EXOKAY
 
         # Matching Exclusive Write - return EXOKAY
         rsp = await self.write(awaddr=0x1000, awid=1, awsize=3, wdata=[0xdeadbeef], wstrb=[0xFF], awlock=1)


### PR DESCRIPTION
added a fix for an error when a read gets DECERR/SVERR and this is overwritten to EXOKAY.
also added a check to not add the exclusivity ranges if we any kind of error.

added an example for those behaviors as well.