### PR TITLE
Support for overriding the responses on write/read driver

### DIFF
--- a/avl_axi/_srdriver.py
+++ b/avl_axi/_srdriver.py
@@ -158,6 +158,11 @@ class SubordinateReadDriver(Driver):
 
             item = await self.get_next_item(self.responseQ[idx])
 
+            # Response override hook (Factory-driven; overridable by subclasses).
+            # Applied once per burst on the first beat; stamps all rresp beats.
+            if item._rcnt_ == 0:
+                self._apply_response_overrides_(item)
+
             # Credit Control
             await self.wait_on_credit("r", [0])
 
@@ -261,6 +266,54 @@ class SubordinateReadDriver(Driver):
 
         return item
 
+    def _apply_response_overrides_(self, item) -> None:
+        """
+        Post-response hook: inspect the whole item and modify its response
+        fields in place before the R-channel beats are driven onto the wire.
+
+        Default behavior:
+        Reads the Factory variable `<full_name>.response_overrides`
+        (default `None`) on every call.
+
+        Expected format: list of dicts:
+          {
+              "resp":        axi_resp_t,        # required
+              "addr_range":  (lo, hi) or None,  # optional, inclusive
+              "match_count": int or None,       # optional (None = unlimited)
+          }
+        Rules are walked in registration order; first match wins. A rule
+        with no `addr_range` matches every transaction. When a rule
+        matches, its `resp` is applied to every `rresp` beat of the
+        burst uniformly. `match_count`, if set, is decremented on match.
+        """
+        overrides = avl.Factory.get_variable(
+            f"{self.get_full_name()}.response_overrides", None
+        )
+        if not overrides:
+            return
+
+        addr = item.get("araddr", default=0)
+
+        for rule in overrides:
+            if rule.get("match_count") is not None and rule["match_count"] <= 0:
+                continue
+
+            addr_range = rule.get("addr_range")
+            if addr_range is not None:
+                lo, hi = addr_range
+                if not (lo <= addr <= hi):
+                    continue
+
+            resp = rule["resp"]
+            nbeats = item.get_rlen() + 1
+            for i in range(nbeats):
+                item.set("rresp", resp, idx=i)
+
+            if rule.get("match_count") is not None:
+                rule["match_count"] -= 1
+
+            break
+            
 class SubordinateReadRandomDriver(SubordinateReadDriver):
 
     async def get_next_item(self, item : SequenceItem = None) -> SequenceItem:

--- a/avl_axi/_swdriver.py
+++ b/avl_axi/_swdriver.py
@@ -233,6 +233,9 @@ class SubordinateWriteDriver(Driver):
             # Exclusive monitor
             self.emonitor.process_write(item)
 
+            # Response override hook (Factory-driven; overridable by subclasses)
+            self._apply_response_overrides_(item)
+
             # Credit Control
             await self.wait_on_credit("b", [0])
 
@@ -311,6 +314,54 @@ class SubordinateWriteDriver(Driver):
 
         return item
 
+    def _apply_response_overrides_(self, item) -> None:
+        """
+        Post-response hook: inspect the whole item and modify its response fields in place before the
+        item is driven onto the B channel.
+
+        Default behavior:
+        Reads the Factory variable `<full_name>.response_overrides`
+        (default is None) on every call, so users may register, replace,
+        or clear rules dynamically at any point during simulation.
+
+        Expected format: list of dicts, each with:
+              {
+                  "resp":        axi_resp_t,        # required
+                  "addr_range":  (lo, hi) or None,  # optional, inclusive
+                  "match_count": int or None,       # optional (None = unlimited)
+              }
+
+        A rule with no addr_range matches every transaction. match_count, if it is set, it is decremented on match;
+        rules with match_count <= 0 are skipped.
+
+        Subclasses may override this method entirely with any matching
+        logic (e.g. by burst type, size, protection, exclusive flag).
+        """
+        overrides = avl.Factory.get_variable(
+            f"{self.get_full_name()}.response_overrides", None
+        )
+        if not overrides:
+            return
+
+        addr = item.get("awaddr", default=0)
+
+        for rule in overrides:
+            if rule.get("match_count") is not None and rule["match_count"] <= 0:
+                continue
+
+            addr_range = rule.get("addr_range")
+            if addr_range is not None:
+                lo, hi = addr_range
+                if not (lo <= addr <= hi):
+                    continue
+
+            item.set("bresp", rule["resp"])
+
+            if rule.get("match_count") is not None:
+                rule["match_count"] -= 1
+
+            break
+            
 class SubordinateWriteMemoryDriver(SubordinateWriteDriver):
 
     def __init__(self, name: str, parent: avl.Component) -> None:


### PR DESCRIPTION
The changes add a support for overriding the response with a parsed response of choice. If the user needs some other way of overriding, a subclass may override these method with any matching logic (e.g. by burst type, size, protection, exclusive flag).

Changes have been tested locally.

Example usages:

avl.Factory.set_variable(
        "*.s_agent.swdrv.response_overrides",
        [
            {"resp": axi_resp_t.SLVERR, "match_count": 5},
        ],
    )
avl.Factory.set_variable(
        "*.s_agent.srdrv.response_overrides",
        [
            {"resp": axi_resp_t.SLVERR, "addr_range": (0x2000, 0x2FFF)},
        ],
    )